### PR TITLE
wip: handle concatenation of trailing slash on path subject to comparison

### DIFF
--- a/lib/Domain/FilePath.php
+++ b/lib/Domain/FilePath.php
@@ -106,7 +106,7 @@ final class FilePath
 
     public function isWithin(FilePath $path)
     {
-        return 0 === strpos($this->path(), $path->path().'/');
+        return 0 === strpos($this->path(), $path->path());
     }
 
     public function isWithinOrSame(FilePath $path)


### PR DESCRIPTION
That was basically what fixed issue https://github.com/phpactor/phpactor/issues/479

Then, the concatenation was probably there for a reason so maybe a check against an existing last ```/``` should be done ?

Or maybe if ```$path->path()``` is the cwd given to the rpc command, then it should be given without trailing ```/``` ?