### PR TITLE
Add support for moving and removing folders

### DIFF
--- a/lib/Adapter/Git/GitFilesystem.php
+++ b/lib/Adapter/Git/GitFilesystem.php
@@ -47,6 +47,11 @@ class GitFilesystem extends SimpleFilesystem
             return parent::remove($path);
         }
 
+        if ($path->isDirectory()) {
+            $this->exec(sprintf('rm -rf %s', $path->path()));
+            return;
+        }
+
         $this->exec(sprintf('rm -f %s', $path->path()));
     }
 

--- a/tests/Adapter/AdapterTestCase.php
+++ b/tests/Adapter/AdapterTestCase.php
@@ -61,6 +61,9 @@ abstract class AdapterTestCase extends IntegrationTestCase
         $this->filesystem()->move($srcLocation, $destLocation);
         $this->assertTrue(file_exists($destLocation->path()));
         $this->assertFalse(file_exists($srcLocation->path()));
+
+        $testFile = $this->filesystem()->createPath('src/Goodbye/Goodbye.php');
+        $this->assertTrue(file_exists($testFile->path()));
     }
 
     public function testCopy()

--- a/tests/Adapter/AdapterTestCase.php
+++ b/tests/Adapter/AdapterTestCase.php
@@ -34,10 +34,29 @@ abstract class AdapterTestCase extends IntegrationTestCase
         $this->assertFalse(file_exists($file->path()));
     }
 
+    public function testRemoveDirectory()
+    {
+        $file = $this->filesystem()->createPath('src/Hello');
+        $this->assertTrue(file_exists($file->path()));
+        $this->filesystem()->remove($file);
+        $this->assertFalse(file_exists($file->path()));
+    }
+
     public function testMove()
     {
         $srcLocation = $this->filesystem()->createPath('src/Hello/Goodbye.php');
         $destLocation = $this->filesystem()->createPath('src/Hello/Hello.php');
+
+        $this->filesystem()->move($srcLocation, $destLocation);
+        $this->assertTrue(file_exists($destLocation->path()));
+        $this->assertFalse(file_exists($srcLocation->path()));
+    }
+
+
+    public function testMoveDirectory()
+    {
+        $srcLocation = $this->filesystem()->createPath('src/Hello');
+        $destLocation = $this->filesystem()->createPath('src/Goodbye');
 
         $this->filesystem()->move($srcLocation, $destLocation);
         $this->assertTrue(file_exists($destLocation->path()));


### PR DESCRIPTION
I've found out that there are warnings returned when running class:move on whole folder. Basically one of the steps is to move the entire folder.

In `SimpleFilesystem::move` method, the php `rename` function won't work if directory is non-empty. I've added a functionality that copies the directory first, and then it removes the original location.

I've added also support for removing whole directories, which is used by rename method. Therefore it forced me to implement same functionality in `GitFIlesystem` to make all tests pass.
