### PR TITLE
Make `named()` require explicit extension

### DIFF
--- a/lib/Domain/FileList.php
+++ b/lib/Domain/FileList.php
@@ -110,7 +110,7 @@ class FileList implements Iterator
     public function named(string $name): self
     {
         return new self(new RegexIterator($this->iterator, sprintf(
-            '{/%s.*$}',
+            '{/%s$}',
             preg_quote($name)
         )));
     }

--- a/tests/Unit/Domain/FileListTest.php
+++ b/tests/Unit/Domain/FileListTest.php
@@ -45,11 +45,15 @@ class FileListTest extends TestCase
     }
 
     /**
-     * It returns all files with given name (including extension).
+     * It returns all PHP files with given name (including extension).
      */
     public function testNamed(): void
     {
         $list = FileList::fromFilePaths([
+            FilePath::fromString('/reports/Foo/Bar.php.html'),
+            FilePath::fromString('/reports/Foo/Foo.php.html'),
+            FilePath::fromString('/reports/Boo/Bar.php.html'),
+            FilePath::fromString('/reports/Foo.php.html'),
             FilePath::fromString('/Foo/Bar.php'),
             FilePath::fromString('/Foo/Foo.php'),
             FilePath::fromString('/Boo/Bar.php'),


### PR DESCRIPTION
The `named` method seems to have been designed to be extension-agnostic,
but the only place it's used is in `ClassSearch`, which passes "Foo.php"
to find matching PHP classes. The unintended consequence of that was it
also got results with `.php.html` extensions, so this removes the `.*`.

**Related:** phpactor/phpactor#1217 (upstream PR)

Fixes phpactor/phpactor#1216